### PR TITLE
Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+script: 
+  - bundle exec rspec

--- a/spec/regularity_spec.rb
+++ b/spec/regularity_spec.rb
@@ -160,14 +160,14 @@ describe Regularity do
 
   context 'examples' do
     specify do
-      re = Regularity.new
-            .start_with(3, :digits)
-            .then('-')
-            .then(2, :letters)
-            .maybe('#')
-            .one_of(['a','b'])
-            .between([2,4], 'c')
-            .end_with('$')
+      re = Regularity.new.
+            start_with(3, :digits).
+            then('-').
+            then(2, :letters).
+            maybe('#').
+            one_of(['a','b']).
+            between([2,4], 'c').
+            end_with('$')
 
       re.regex.should == /^[0-9]{3}-[A-Za-z]{2}#?[a|b]c{2,4}\$$/
 


### PR DESCRIPTION
This PR adds the configuration needs for Travis CI integration.  @andrewberls will still need to turn on Travis CI for this repo after the PR is merged.

Key changes:
1. Added basic Travis config.
2. Updated spec syntax to be Ruby 1.8.7 compatible.  I didn't see any reason to exclude it at this point.
