### PR TITLE
Improve test speed

### DIFF
--- a/lib/regularity.rb
+++ b/lib/regularity.rb
@@ -64,10 +64,6 @@ class Regularity
   def =~(other)
     regex =~ other
   end
-  
-  def reset
-    @str = ''
-  end
 
   def method_missing(meth, *args, &block)
     regex.send(meth, *args, &block)


### PR DESCRIPTION
Rather than instantiating a new Regularity instance for each spec, I've added a reset method that blanks the string and added before and after blocks to the specs that instantiate a Regularity object on the first spec and reset it's string after each spec. First test stats in below screenshot are before changes, second set (after the error was fixed) are using the new code.

![screen shot 2013-10-03 at 13 01 24](https://f.cloud.github.com/assets/35007/1261108/658a91d0-2c24-11e3-86d1-143ddf17b56a.png)

Like this library and would love to contribute!
