### PR TITLE
Raise error if appending after #end_with called

### DIFF
--- a/lib/regularity.rb
+++ b/lib/regularity.rb
@@ -19,6 +19,7 @@ class Regularity
 
   def initialize
     @str = ''
+    @ended = false
   end
 
   def start_with(*args)
@@ -33,6 +34,8 @@ class Regularity
 
   def end_with(*args)
     write '%s$', args
+    @ended = true
+    self
   end
 
   def maybe(*args)
@@ -92,6 +95,7 @@ class Regularity
   private
 
   def write(str, args=nil)
+    raise Regularity::Error.new('#end_with has already been called') if @ended
     @str << (args.nil? ? str : str % interpret(*args))
     self
   end

--- a/spec/regularity_spec.rb
+++ b/spec/regularity_spec.rb
@@ -54,6 +54,12 @@ describe Regularity do
       re.between([0,2], :digits).then('.').end_with('$')
       re.get.should == /[0-9]{0,2}\.\$$/
     end
+
+    it 'raises an error after ending' do
+      expect do
+        re.end_with('x').append('y')
+      end.to raise_error(Regularity::Error)
+    end
   end
 
   context '#maybe' do
@@ -126,6 +132,12 @@ describe Regularity do
     it 'escapes special characters' do
       re.append('x').end_with('$')
       re.get.should == /x\$$/
+    end
+
+    it 'raises an error when called twice' do
+      expect do
+        re.end_with('x').end_with('x')
+      end.to raise_error(Regularity::Error)
     end
   end
 


### PR DESCRIPTION
Raises an error if a user attempts to append more to the regex after #end_with has already been called:

```
Regularity.new
  .start_with(3, :digits)
  .end_with('$')
  .then('-')  # raises Regularity::Error
```

This provides symmetry to the error raised if #start_with gets called and it's not the beginning of the regex.
